### PR TITLE
 v0.3.0: config file, schemify command, --info, single-model naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,44 +29,27 @@ pip install "dbt-schemify[duckdb]"
 
 ## Quick start
 
-**1. Create a `.schemify.yml` template** in your dbt project root:
-
-```yaml
-version: '1.0'
-models:
-  - name: schemify
-    description: schemify      # filled from manifest
-    meta:
-      owner: analytics         # static default applied to all models
-    config:
-      enabled: true            # static default
-    columns:
-      - name: schemify
-        data_type: schemify    # filled from DB
-        description: schemify  # left empty for humans to fill in
-        meta:
-          gdpr_tags: schemify
-```
-
-**2. Compile your dbt project** to get a manifest:
+**1. Compile your dbt project** to get a manifest:
 
 ```bash
 dbt compile
 ```
 
-**3. Run dbt-schemify:**
+**2. Run schemify:**
 
 ```bash
-dbt-schemify
+schemify
 ```
 
+If `.schemify.yml` doesn't exist yet, schemify creates one with sensible defaults — edit it, then re-run.
+
 Reads `.schemify.yml`, `target/manifest.json`, and `~/.dbt/profiles.yml` automatically.
-Writes `schema.yml` next to each model's SQL file.
+Writes `schema.yml` next to each model's SQL file (grouped by folder).
 
 ## Usage
 
 ```
-dbt-schemify [options]
+schemify [options]
 
 Options:
   --schema PATH          Write all models into a single schema.yml at PATH.
@@ -83,36 +66,66 @@ Options:
                          Examples: -s orders   -s tag:marketing   -s tag:finance orders
   --each                 Write one <model_name>.yml per model instead of one schema.yml per folder
   --no-db                Skip database connection; no column fetching
+  --info                 Show resolved paths and configuration, then exit
 ```
+
+> `dbt-schemify` also works as an alias for backward compatibility.
 
 ## Examples
 
 ```bash
 # Auto-discover: write schema.yml next to every model's SQL file
-dbt-schemify
+schemify
+
+# Check which paths schemify is using
+schemify --info
 
 # Only models with a specific tag (one schema.yml per directory)
-dbt-schemify -s tag:marketing
+schemify -s tag:marketing
 
 # Only specific models by name
-dbt-schemify -s orders customers
+schemify -s orders customers
+
+# Single model — automatically gets its own <model_name>.yml
+schemify -s orders
 
 # Mix names and tags
-dbt-schemify -s tag:finance orders
+schemify -s tag:finance orders
 
 # All matching models into one explicit file
-dbt-schemify --schema models/marketing/schema.yml -s tag:marketing
+schemify --schema models/marketing/schema.yml -s tag:marketing
 
 # One file per model named after the model (e.g. orders.yml, customers.yml)
-dbt-schemify --each
+schemify --each
 
 # Without DB connection (manifest data only)
-dbt-schemify --no-db
+schemify --no-db
 
 # Custom paths
-dbt-schemify \
+schemify \
   --manifest target/manifest.json \
   --template .schemify.yml
+```
+
+## Default template
+
+If `.schemify.yml` is missing, schemify creates this template automatically:
+
+```yaml
+version: '1.0'
+models:
+  - name: schemify
+    description: schemify      # filled from manifest
+    meta:
+      owner: analytics         # static default applied to all models
+    config:
+      enabled: true            # static default
+    columns:
+      - name: schemify
+        data_type: schemify    # filled from DB
+        description: schemify  # left empty for humans to fill in
+        meta:
+          gdpr_tags: schemify
 ```
 
 ## Merge rules

--- a/dbt_schemify/main.py
+++ b/dbt_schemify/main.py
@@ -32,6 +32,8 @@ from dbt_schemify.schema_editor import CustomDumper
 from dbt_schemify.dbt_ast import ModelNode
 from dbt_schemify.transformation import SchemifyTransformer
 
+CONFIG_FILE = '.schemify-config.yml'
+
 DEFAULT_TEMPLATE = """\
 version: '1.0'
 models:
@@ -45,6 +47,26 @@ models:
       - name: schemify
         data_type: schemify
 
+"""
+
+DEFAULT_CONFIG = """\
+# schemify configuration
+# Values here are used as defaults on every run.
+# Command-line arguments always take priority over this file.
+# Use 'default' for paths/names to let schemify auto-resolve them.
+
+# Output mode
+each: false          # write one <model>.yml per model instead of schema.yml per folder
+no_db: false         # skip database connection; no column fetching
+
+# Paths ('default' = auto-resolved)
+manifest: default    # manifest.json path;      auto: <project-dir>/target/manifest.json
+template: default    # .schemify.yml path;       auto: <project-dir>/.schemify.yml
+profiles_dir: default  # profiles.yml directory; auto: ~/.dbt/
+
+# dbt connection ('default' = auto-resolved)
+profile: default     # dbt profile name;  auto: read from dbt_project.yml
+target: default      # dbt target name;   auto: profile default
 """
 
 
@@ -159,6 +181,31 @@ def _ensure_template(template_path):
     print("Edit it to customise which fields schemify generates, then re-run.")
 
 
+def _load_config(project_dir):
+    """Read .schemify-config.yml from project_dir.
+    Creates it with defaults if missing. Returns dict with 'default' normalised to None.
+    """
+    config_path = Path(project_dir) / CONFIG_FILE
+    if not config_path.exists():
+        with open(config_path, 'w', encoding='utf-8') as f:
+            f.write(DEFAULT_CONFIG)
+        print(f"Created config file at {config_path}")
+        print(f"Review it to set your preferred defaults, then re-run.")
+    with open(config_path) as f:
+        raw = yaml.safe_load(f) or {}
+    # Normalise the 'default' sentinel string to None everywhere
+    return {k: (None if v == 'default' else v) for k, v in raw.items()}
+
+
+def _resolve(cli_val, config_val, hardcoded):
+    """Priority: CLI arg > config file > hardcoded default."""
+    if cli_val is not None:
+        return cli_val
+    if config_val is not None:
+        return config_val
+    return hardcoded
+
+
 def main():
     parser = argparse.ArgumentParser(
         prog='schemify',
@@ -180,9 +227,11 @@ def main():
                         help='Directory containing profiles.yml. Default: ~/.dbt/')
     parser.add_argument('-s', '--select', nargs='+', metavar='SELECTOR',
                         help='Filter models. Supports model names and tag:value (e.g. -s tag:marketing orders).')
-    parser.add_argument('--each', action='store_true',
+    # Use default=None so we can distinguish "user passed this flag" from "not passed"
+    # (needed to let config-file values win when the flag is absent)
+    parser.add_argument('--each', action='store_true', default=None,
                         help='Write one <model_name>.yml per model instead of one schema.yml per folder.')
-    parser.add_argument('--no-db', action='store_true',
+    parser.add_argument('--no-db', action='store_true', default=None,
                         help='Skip database connection and column fetching.')
     parser.add_argument('--info', action='store_true',
                         help='Show resolved paths and configuration, then exit.')
@@ -190,27 +239,42 @@ def main():
     args = parser.parse_args()
     project_dir = Path(args.project_dir).resolve()
 
-    template_path = Path(args.template).resolve() if args.template else project_dir / '.schemify.yml'
-    manifest_path = Path(args.manifest).resolve() if args.manifest else project_dir / 'target' / 'manifest.json'
-    profiles_dir = Path(args.profiles_dir).resolve() if args.profiles_dir else Path.home() / '.dbt'
+    # --- Config file (create if missing, always read) ---
+    cfg = _load_config(project_dir)
 
-    dbt_project = _read_dbt_project(project_dir)
-    profile_name = args.profile or dbt_project.get('profile', '<not set>')
+    # --- Resolve all options: CLI > config > hardcoded default ---
+    each   = _resolve(args.each,       cfg.get('each'),         False)
+    no_db  = _resolve(args.no_db,      cfg.get('no_db'),        False)
+    manifest_arg   = args.manifest    or cfg.get('manifest')    # None → auto
+    template_arg   = args.template    or cfg.get('template')    # None → auto
+    profiles_dir_arg = args.profiles_dir or cfg.get('profiles_dir')  # None → auto
+    profile_arg    = args.profile     or cfg.get('profile')     # None → auto
+    target_arg     = args.target      or cfg.get('target')      # None → auto
+
+    template_path  = Path(template_arg).resolve()  if template_arg   else project_dir / '.schemify.yml'
+    manifest_path  = Path(manifest_arg).resolve()  if manifest_arg   else project_dir / 'target' / 'manifest.json'
+    profiles_dir   = Path(profiles_dir_arg).resolve() if profiles_dir_arg else Path.home() / '.dbt'
+
+    dbt_project  = _read_dbt_project(project_dir)
+    profile_name = profile_arg or dbt_project.get('profile', '<not set>')
 
     # --- --info mode ---
     if args.info:
+        config_path = project_dir / CONFIG_FILE
         print(f"project-dir  : {project_dir}")
+        print(f"config       : {config_path}  {'(exists)' if config_path.exists() else '(missing)'}")
         print(f"template     : {template_path}  {'(exists)' if template_path.exists() else '(missing)'}")
         print(f"manifest     : {manifest_path}  {'(exists)' if manifest_path.exists() else '(missing)'}")
         print(f"profiles-dir : {profiles_dir}  {'(exists)' if profiles_dir.exists() else '(missing)'}")
         print(f"profile      : {profile_name}")
-        print(f"target       : {args.target or '(default)'}")
+        print(f"target       : {target_arg or '(default)'}")
+        print(f"each         : {each}")
+        print(f"no-db        : {no_db}")
         return
 
     # --- Template ---
     if not template_path.exists():
-        if args.template:
-            # User explicitly pointed at a path that doesn't exist — still an error
+        if template_arg:
             print(f"Error: template not found: {template_path}", file=sys.stderr)
             print("Create a .schemify.yml in your project root or pass --template.", file=sys.stderr)
             sys.exit(1)
@@ -238,8 +302,8 @@ def main():
 
     # --- DB columns ---
     db_cols_by_model = {}
-    if not args.no_db:
-        resolved_profile = args.profile or dbt_project.get('profile')
+    if not no_db:
+        resolved_profile = profile_arg or dbt_project.get('profile')
 
         if not resolved_profile:
             print(
@@ -250,9 +314,9 @@ def main():
         else:
             try:
                 from dbt_schemify.db_connector import read_connection_config
-                config = read_connection_config(resolved_profile, args.target, args.profiles_dir)
-                print(f"Connecting to {config.get('type')} ({resolved_profile}/{args.target or 'default'})...")
-                db_cols_by_model = _fetch_db_columns(manifest_nodes, config)
+                db_config = read_connection_config(resolved_profile, target_arg, profiles_dir_arg)
+                print(f"Connecting to {db_config.get('type')} ({resolved_profile}/{target_arg or 'default'})...")
+                db_cols_by_model = _fetch_db_columns(manifest_nodes, db_config)
             except Exception as exc:
                 print(f"Warning: DB connection failed — {exc}", file=sys.stderr)
                 print("Proceeding without column information.", file=sys.stderr)
@@ -263,8 +327,8 @@ def main():
     if args.schema:
         # Explicit output file — all selected models into one schema.yml
         _write_schema(Path(args.schema), manifest_nodes, template_model, db_cols_by_model)
-    elif args.each or len(manifest_nodes) == 1:
-        # One <model_name>.yml per model (explicit --each, or exactly one model selected)
+    elif each or len(manifest_nodes) == 1:
+        # One <model_name>.yml per model (explicit --each / config each:true, or exactly one model selected)
         groups = _group_nodes_by_model(manifest_nodes, project_dir)
         if not groups:
             print("No models found to process.", file=sys.stderr)

--- a/dbt_schemify/main.py
+++ b/dbt_schemify/main.py
@@ -1,9 +1,9 @@
 """
-dbt-schemify CLI
+schemify CLI
 
 Usage:
-  dbt-schemify                         # auto-discover: writes schema.yml next to each model
-  dbt-schemify --schema path/schema.yml  # explicit: write all selected models into one file
+  schemify                         # auto-discover: writes schema.yml next to each model
+  schemify --schema path/schema.yml  # explicit: write all selected models into one file
 
 All options:
   --schema         PATH   Path to schema.yml to write (optional; default: auto-discover from manifest)
@@ -17,6 +17,7 @@ All options:
                              Examples: -s my_model   -s tag:marketing   -s tag:finance orders
   --each                  Write one <model_name>.yml per model instead of one schema.yml per folder
   --no-db                 Skip database connection; no column fetching
+  --info                  Show resolved paths and configuration, then exit
 """
 
 import argparse
@@ -30,6 +31,21 @@ import yaml
 from dbt_schemify.schema_editor import CustomDumper
 from dbt_schemify.dbt_ast import ModelNode
 from dbt_schemify.transformation import SchemifyTransformer
+
+DEFAULT_TEMPLATE = """\
+version: '1.0'
+models:
+  - name: schemify
+    description: schemify
+    meta:
+      owner: analytics
+    config:
+      enabled: true
+    columns:
+      - name: schemify
+        data_type: schemify
+
+"""
 
 
 def _read_dbt_project(project_dir):
@@ -134,9 +150,18 @@ def _fetch_db_columns(manifest_nodes, config):
     return db_cols
 
 
+def _ensure_template(template_path):
+    """Create a default .schemify.yml if it doesn't exist yet."""
+    template_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(template_path, 'w', encoding='utf-8') as f:
+        f.write(DEFAULT_TEMPLATE)
+    print(f"Created default template at {template_path}")
+    print("Edit it to customise which fields schemify generates, then re-run.")
+
+
 def main():
     parser = argparse.ArgumentParser(
-        prog='dbt-schemify',
+        prog='schemify',
         description='Generate and update dbt schema.yml files.',
     )
     parser.add_argument('--schema',
@@ -159,21 +184,43 @@ def main():
                         help='Write one <model_name>.yml per model instead of one schema.yml per folder.')
     parser.add_argument('--no-db', action='store_true',
                         help='Skip database connection and column fetching.')
+    parser.add_argument('--info', action='store_true',
+                        help='Show resolved paths and configuration, then exit.')
 
     args = parser.parse_args()
-    project_dir = Path(args.project_dir)
+    project_dir = Path(args.project_dir).resolve()
+
+    template_path = Path(args.template).resolve() if args.template else project_dir / '.schemify.yml'
+    manifest_path = Path(args.manifest).resolve() if args.manifest else project_dir / 'target' / 'manifest.json'
+    profiles_dir = Path(args.profiles_dir).resolve() if args.profiles_dir else Path.home() / '.dbt'
+
+    dbt_project = _read_dbt_project(project_dir)
+    profile_name = args.profile or dbt_project.get('profile', '<not set>')
+
+    # --- --info mode ---
+    if args.info:
+        print(f"project-dir  : {project_dir}")
+        print(f"template     : {template_path}  {'(exists)' if template_path.exists() else '(missing)'}")
+        print(f"manifest     : {manifest_path}  {'(exists)' if manifest_path.exists() else '(missing)'}")
+        print(f"profiles-dir : {profiles_dir}  {'(exists)' if profiles_dir.exists() else '(missing)'}")
+        print(f"profile      : {profile_name}")
+        print(f"target       : {args.target or '(default)'}")
+        return
 
     # --- Template ---
-    template_path = Path(args.template) if args.template else project_dir / '.schemify.yml'
     if not template_path.exists():
-        print(f"Error: template not found: {template_path}", file=sys.stderr)
-        print("Create a .schemify.yml in your project root or pass --template.", file=sys.stderr)
-        sys.exit(1)
+        if args.template:
+            # User explicitly pointed at a path that doesn't exist — still an error
+            print(f"Error: template not found: {template_path}", file=sys.stderr)
+            print("Create a .schemify.yml in your project root or pass --template.", file=sys.stderr)
+            sys.exit(1)
+        _ensure_template(template_path)
+        sys.exit(0)
+
     with open(template_path) as f:
         template = yaml.safe_load(f) or {}
 
     # --- Manifest ---
-    manifest_path = Path(args.manifest) if args.manifest else project_dir / 'target' / 'manifest.json'
     if not manifest_path.exists():
         print(
             f"Error: manifest.json not found at {manifest_path}.\n"
@@ -192,10 +239,9 @@ def main():
     # --- DB columns ---
     db_cols_by_model = {}
     if not args.no_db:
-        dbt_project = _read_dbt_project(project_dir)
-        profile_name = args.profile or dbt_project.get('profile')
+        resolved_profile = args.profile or dbt_project.get('profile')
 
-        if not profile_name:
+        if not resolved_profile:
             print(
                 "Warning: no profile name found. Pass --profile or set 'profile' in dbt_project.yml. "
                 "Skipping DB connection.",
@@ -204,8 +250,8 @@ def main():
         else:
             try:
                 from dbt_schemify.db_connector import read_connection_config
-                config = read_connection_config(profile_name, args.target, args.profiles_dir)
-                print(f"Connecting to {config.get('type')} ({profile_name}/{args.target or 'default'})...")
+                config = read_connection_config(resolved_profile, args.target, args.profiles_dir)
+                print(f"Connecting to {config.get('type')} ({resolved_profile}/{args.target or 'default'})...")
                 db_cols_by_model = _fetch_db_columns(manifest_nodes, config)
             except Exception as exc:
                 print(f"Warning: DB connection failed — {exc}", file=sys.stderr)
@@ -217,8 +263,8 @@ def main():
     if args.schema:
         # Explicit output file — all selected models into one schema.yml
         _write_schema(Path(args.schema), manifest_nodes, template_model, db_cols_by_model)
-    elif args.each:
-        # One <model_name>.yml per model
+    elif args.each or len(manifest_nodes) == 1:
+        # One <model_name>.yml per model (explicit --each, or exactly one model selected)
         groups = _group_nodes_by_model(manifest_nodes, project_dir)
         if not groups:
             print("No models found to process.", file=sys.stderr)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ bigquery  = ["google-cloud-bigquery"]
 duckdb    = ["duckdb"]
 
 [project.scripts]
+schemify = "dbt_schemify.main:main"
 dbt-schemify = "dbt_schemify.main:main"
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dbt-schemify"
-version = "0.2.0"
+version = "0.3.0"
 description = "Generate and update dbt schema.yml files from a template, manifest, and database"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,14 @@
 from pathlib import Path
 
-from dbt_schemify.main import _apply_selector, _group_nodes_by_dir, _group_nodes_by_model
+from dbt_schemify.main import (
+    _apply_selector,
+    _group_nodes_by_dir,
+    _group_nodes_by_model,
+    _load_config,
+    _resolve,
+    CONFIG_FILE,
+    DEFAULT_CONFIG,
+)
 
 
 def _node(name, tags=None, original_file_path=None):
@@ -175,3 +183,72 @@ class TestSingleModelDispatch:
         dir_path = next(iter(by_dir))
         assert model_path.name == 'orders.yml'
         assert dir_path.name == 'schema.yml'
+
+
+# ---------------------------------------------------------------------------
+# _resolve (CLI > config > hardcoded default)
+# ---------------------------------------------------------------------------
+
+class TestResolve:
+    def test_cli_wins_over_config_and_default(self):
+        assert _resolve('cli', 'cfg', 'default') == 'cli'
+
+    def test_config_wins_over_default_when_cli_is_none(self):
+        assert _resolve(None, 'cfg', 'default') == 'cfg'
+
+    def test_hardcoded_default_used_when_both_none(self):
+        assert _resolve(None, None, 'default') == 'default'
+
+    def test_false_cli_value_not_treated_as_none(self):
+        # False is a valid CLI value (e.g. --each not passed gives None, not False)
+        assert _resolve(False, True, True) is False
+
+    def test_zero_cli_value_not_treated_as_none(self):
+        assert _resolve(0, 99, 99) == 0
+
+
+# ---------------------------------------------------------------------------
+# _load_config
+# ---------------------------------------------------------------------------
+
+class TestLoadConfig:
+    def test_creates_config_file_if_missing(self, tmp_path):
+        cfg = _load_config(tmp_path)
+        assert (tmp_path / CONFIG_FILE).exists()
+        # Returns a dict
+        assert isinstance(cfg, dict)
+
+    def test_created_file_contains_expected_keys(self, tmp_path):
+        _load_config(tmp_path)
+        text = (tmp_path / CONFIG_FILE).read_text()
+        assert 'each' in text
+        assert 'no_db' in text
+        assert 'manifest' in text
+
+    def test_default_sentinel_normalised_to_none(self, tmp_path):
+        cfg = _load_config(tmp_path)
+        # 'default' strings in DEFAULT_CONFIG should become None
+        assert cfg.get('manifest') is None
+        assert cfg.get('profile') is None
+        assert cfg.get('target') is None
+
+    def test_bool_defaults_preserved(self, tmp_path):
+        cfg = _load_config(tmp_path)
+        assert cfg.get('each') is False
+        assert cfg.get('no_db') is False
+
+    def test_reads_existing_config(self, tmp_path):
+        (tmp_path / CONFIG_FILE).write_text('each: true\nno_db: false\n')
+        cfg = _load_config(tmp_path)
+        assert cfg.get('each') is True
+        assert cfg.get('no_db') is False
+
+    def test_custom_value_not_normalised(self, tmp_path):
+        (tmp_path / CONFIG_FILE).write_text('profile: my_profile\n')
+        cfg = _load_config(tmp_path)
+        assert cfg.get('profile') == 'my_profile'
+
+    def test_default_config_content_matches_constant(self, tmp_path):
+        _load_config(tmp_path)
+        written = (tmp_path / CONFIG_FILE).read_text()
+        assert written == DEFAULT_CONFIG

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -148,3 +148,30 @@ class TestGroupNodesByModel:
         nodes = [{'name': 'broken', 'tags': []}]
         groups = _group_nodes_by_model(nodes, project_dir='.')
         assert len(groups) == 0
+
+
+# ---------------------------------------------------------------------------
+# Single-model dispatch helper
+# ---------------------------------------------------------------------------
+
+class TestSingleModelDispatch:
+    """When exactly one node is selected, the output file is named after the model."""
+
+    def test_single_node_produces_model_named_file(self):
+        nodes = [_node('orders', original_file_path='models/finance/orders.sql')]
+        # Single model → should use _group_nodes_by_model logic (named file)
+        groups = _group_nodes_by_model(nodes, project_dir='.')
+        assert len(groups) == 1
+        schema_path = next(iter(groups))
+        assert schema_path.name == 'orders.yml'
+        assert schema_path == Path('.') / 'models' / 'finance' / 'orders.yml'
+
+    def test_single_node_vs_multi_dir_differ(self):
+        """Single-node path differs from multi-node default (schema.yml)."""
+        nodes = [_node('orders', original_file_path='models/finance/orders.sql')]
+        by_model = _group_nodes_by_model(nodes, project_dir='.')
+        by_dir = _group_nodes_by_dir(nodes, project_dir='.')
+        model_path = next(iter(by_model))
+        dir_path = next(iter(by_dir))
+        assert model_path.name == 'orders.yml'
+        assert dir_path.name == 'schema.yml'


### PR DESCRIPTION
## Summary

- `.schemify-config.yml` — auto-created on first run with all options and defaults;
  read every run so users set persistent preferences. CLI always overrides config.
- `schemify` command — renamed from `dbt-schemify`; old name kept as alias.
- `--info` flag — prints all resolved paths and effective settings, then exits.
- Single-model auto-naming — `-s orders` automatically writes `orders.yml`.

## Test plan
- [ ] `schemify --info` prints correct paths
- [ ] First run creates `.schemify-config.yml` in project root
- [ ] `each: true` in config makes all runs use per-model files
- [ ] `no_db: true` in config skips DB on every run
- [ ] CLI `--each` overrides `each: false` in config
- [ ] `schemify -s one_model` writes `one_model.yml`
- [ ] `dbt-schemify` alias still works
- 82 tests passing